### PR TITLE
Added 'Other' as an accepted Track @type.

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -107,7 +107,7 @@ export interface MediaInfo {
 }
 
 export type Track = {
-  '@type': 'General' | 'Video' | 'Audio' | 'Text' | 'Image' | 'Chapters' | 'Menu'
+  '@type': 'General' | 'Video' | 'Audio' | 'Text' | 'Image' | 'Chapters' | 'Menu' | 'Other'
   // Endless more properties:
   // https://github.com/MediaArea/MediaInfoLib/tree/master/Source/Resource/Text/Stream
 } & Record<string, unknown>


### PR DESCRIPTION
Many RAW video codecs when parsed via MediaInfo.js return 'Other' tracks like so:

```JSON
{
          "@type": "Other",
          "StreamOrder": "2",
          "ID": "3",
          "Type": "Time code",
          "Format": "QuickTime TC",
          "Duration": "7.841",
          "FrameRate": "23.976",
          "FrameCount": "188",
          "TimeCode_FirstFrame": "22:03:40:10",
          "TimeCode_LastFrame": "22:03:48:05",
          "TimeCode_Stripped": "Yes",
          "Language": "en",
          "extra": {
            "Encoded_Date": "UTC 2023-02-12 05:02:46",
            "Tagged_Date": "UTC 2023-02-12 05:02:46",
          },
}
```

I'm keeping data like this within our test suites, and I currently have to // @ts-ignore the @type field due to the mistake.