### PR TITLE
build(deps): Update libmediainfo to v24.01

### DIFF
--- a/gulp/constants.ts
+++ b/gulp/constants.ts
@@ -7,7 +7,7 @@ const DIST_DIR = join(PROJECT_DIR, 'dist')
 const BUILD_DIR = join(PROJECT_DIR, 'build')
 const VENDOR_DIR = join(BUILD_DIR, 'vendor')
 
-const LIBMEDIAINFO_VERSION = '23.07'
+const LIBMEDIAINFO_VERSION = '24.01'
 const LIBZEN_VERSION = '0.4.41'
 
 const CFLAGS = '-Oz'


### PR DESCRIPTION
* Upgrade libmediainfo to latest
  * from: v23.07 (Jul 12, 2023)
  * to v24.01 (Jan 31, 2024)
* Changelog: https://github.com/MediaArea/MediaInfoLib/releases
* Diff: https://github.com/MediaArea/MediaInfoLib/compare/v23.07...v24.01