### PR TITLE
Compile WASM with `DYNAMIC_EXECUTION=0`

### DIFF
--- a/gulp/compile/wasm.ts
+++ b/gulp/compile/wasm.ts
@@ -16,6 +16,9 @@ function makeArgs(environment: 'web' | 'node', es6: boolean) {
     ...MediaInfoLib_CXXFLAGS.split(' '),
     `-INITIAL_HEAP=${WASM_INITIAL_MEMORY}`,
     '-sALLOW_MEMORY_GROWTH=1',
+    // Disallow eval/new Function in generated JS to be CSP-friendly
+    // See https://emscripten.org/docs/tools_reference/settings_reference.html#dynamic-execution
+    '-sDYNAMIC_EXECUTION=0',
     '-sMALLOC=emmalloc',
     '-sASSERTIONS=0',
     `-sENVIRONMENT=${environment}`,

--- a/gulp/generate-types/data/parseXsd.ts
+++ b/gulp/generate-types/data/parseXsd.ts
@@ -105,6 +105,8 @@ async function parseXsd() {
   properties.HDR_Format_Compression = { type: 'string' }
   properties.Encoded_OperatingSystem_String = { type: 'string' }
   properties.Encoded_Hardware_String = { type: 'string' }
+  properties.MasteringDisplay_Luminance_Original_Min = { type: 'string' }
+  properties.MasteringDisplay_Luminance_Original_Max = { type: 'string' }
 
   return { properties, intFields, floatFields }
 }

--- a/src/MediaInfoResult.ts
+++ b/src/MediaInfoResult.ts
@@ -108,6 +108,12 @@ export const FLOAT_FIELDS = [
   'Interleave_Duration',
   'Interleave_Preload',
   'Interleave_VideoFrames',
+  'MasteringDisplay_Luminance_Max',
+  'MasteringDisplay_Luminance_Min',
+  'MaxCLL',
+  'MaxCLL_Original',
+  'MaxFALL',
+  'MaxFALL_Original',
   'OverallBitRate_Maximum',
   'OverallBitRate_Minimum',
   'OverallBitRate',
@@ -1515,24 +1521,40 @@ export interface ImageTrack extends BaseTrack {
   readonly MasteringDisplay_Luminance?: string
   /** Luminance of the mastering display (source) */
   readonly MasteringDisplay_Luminance_Source?: string
+  /** Min luminance of the mastering display */
+  readonly MasteringDisplay_Luminance_Min?: number
+  /** Max luminance of the mastering display */
+  readonly MasteringDisplay_Luminance_Max?: number
   /** Luminance of the mastering display (if incoherencies) */
   readonly MasteringDisplay_Luminance_Original?: string
   /** Luminance of the mastering display (source if incoherencies) */
   readonly MasteringDisplay_Luminance_Original_Source?: string
+  /** Min luminance of the mastering display (source if incoherencies) */
+  readonly MasteringDisplay_Luminance_Original_Min?: string
+  /** Max luminance of the mastering display (source if incoherencies) */
+  readonly MasteringDisplay_Luminance_Original_Max?: string
   /** Maximum content light level */
-  readonly MaxCLL?: string
+  readonly MaxCLL?: number
+  /** Maximum content light level, with measurement */
+  readonly MaxCLL_String?: string
   /** Maximum content light level (source) */
   readonly MaxCLL_Source?: string
+  /** Maximum content light level (if incoherencies), with measurement */
+  readonly MaxCLL_Original?: number
   /** Maximum content light level (if incoherencies) */
-  readonly MaxCLL_Original?: string
+  readonly MaxCLL_Original_String?: string
   /** Maximum content light level (source if incoherencies) */
   readonly MaxCLL_Original_Source?: string
   /** Maximum frame average light level */
-  readonly MaxFALL?: string
-  /** Maximum frame average light level (source) */
+  readonly MaxFALL?: number
+  /** Maximum frame average light level */
+  readonly MaxFALL_String?: string
+  /** Maximum frame average light level (source), with measurement */
   readonly MaxFALL_Source?: string
   /** Maximum frame average light level (if incoherencies) */
-  readonly MaxFALL_Original?: string
+  readonly MaxFALL_Original?: number
+  /** Maximum frame average light level (if incoherencies), with measurement */
+  readonly MaxFALL_Original_String?: string
   /** Maximum frame average light level (source if incoherencies) */
   readonly MaxFALL_Original_Source?: string
 }
@@ -2009,33 +2031,33 @@ export interface TextTrack extends BaseTrack {
   readonly Duration_Start_String4?: string
   /** Timestamp of first display in format HH:MM:SS.mmm (HH:MM:SS:FF) */
   readonly Duration_Start_String5?: string
-  /** Play time of the stream, in s (ms for text output) */
+  /** Timestamp of after the last display, in s (ms for text output) */
   readonly Duration_End?: number
-  /** Play time in format XXx YYy, with YYy value omitted if zero (e.g. 1 h 40 min) */
+  /** Timestamp of after the last display in format XXx YYy, with YYy value omitted if zero (e.g. 1 h 40 min) */
   readonly Duration_End_String?: string
-  /** Play time in format HHh MMmn SSs MMMms, with any fields omitted if zero */
+  /** Timestamp of after the last display in format HHh MMmn SSs MMMms, with any fields omitted if zero */
   readonly Duration_End_String1?: string
-  /** Play time in format XXx YYy, with YYy omitted if value is zero */
+  /** Timestamp of after the last display in format XXx YYy, with YYy omitted if value is zero */
   readonly Duration_End_String2?: string
-  /** Play time in format HH:MM:SS.mmm */
+  /** Timestamp of after the last display in format HH:MM:SS.mmm */
   readonly Duration_End_String3?: string
-  /** Play time in format HH:MM:SS:FF, with last colon replaced by semicolon for drop frame if available */
+  /** Timestamp of after the last display in format HH:MM:SS:FF, with last colon replaced by semicolon for drop frame if available */
   readonly Duration_End_String4?: string
-  /** Play time in format HH:MM:SS.mmm (HH:MM:SS:FF) */
+  /** Timestamp of after the last display in format HH:MM:SS.mmm (HH:MM:SS:FF) */
   readonly Duration_End_String5?: string
-  /** Play time of the stream, in s (ms for text output) */
+  /** Timestamp of the last command, in s (ms for text output) */
   readonly Duration_End_Command?: number
-  /** Play time in format XXx YYy, with YYy value omitted if zero (e.g. 1 h 40 min) */
+  /** Timestamp of the last command in format XXx YYy, with YYy value omitted if zero (e.g. 1 h 40 min) */
   readonly Duration_End_Command_String?: string
-  /** Play time in format HHh MMmn SSs MMMms, with any fields omitted if zero */
+  /** Timestamp of the last command in format HHh MMmn SSs MMMms, with any fields omitted if zero */
   readonly Duration_End_Command_String1?: string
-  /** Play time in format XXx YYy, with YYy omitted if value is zero */
+  /** Timestamp of the last command in format XXx YYy, with YYy omitted if value is zero */
   readonly Duration_End_Command_String2?: string
-  /** Play time in format HH:MM:SS.mmm */
+  /** PTimestamp of the last command in format HH:MM:SS.mmm */
   readonly Duration_End_Command_String3?: string
-  /** Play time in format HH:MM:SS:FF, with last colon replaced by semicolon for drop frame if available */
+  /** Timestamp of the last command in format HH:MM:SS:FF, with last colon replaced by semicolon for drop frame if available */
   readonly Duration_End_Command_String4?: string
-  /** Play time in format HH:MM:SS.mmm (HH:MM:SS:FF) */
+  /** Timestamp of the last command in format HH:MM:SS.mmm (HH:MM:SS:FF) */
   readonly Duration_End_Command_String5?: string
   /** Duration of the first frame (if different than other frames), in ms */
   readonly Duration_FirstFrame?: number
@@ -3096,24 +3118,40 @@ export interface VideoTrack extends BaseTrack {
   readonly MasteringDisplay_Luminance?: string
   /** Luminance of the mastering display (source) */
   readonly MasteringDisplay_Luminance_Source?: string
+  /** Min luminance of the mastering display */
+  readonly MasteringDisplay_Luminance_Min?: number
+  /** Max luminance of the mastering display */
+  readonly MasteringDisplay_Luminance_Max?: number
   /** Luminance of the mastering display (if incoherencies) */
   readonly MasteringDisplay_Luminance_Original?: string
   /** Luminance of the mastering display (source if incoherencies) */
   readonly MasteringDisplay_Luminance_Original_Source?: string
+  /** Min luminance of the mastering display (source if incoherencies) */
+  readonly MasteringDisplay_Luminance_Original_Min?: string
+  /** Max luminance of the mastering display (source if incoherencies) */
+  readonly MasteringDisplay_Luminance_Original_Max?: string
   /** Maximum content light level */
-  readonly MaxCLL?: string
+  readonly MaxCLL?: number
+  /** Maximum content light level, with measurement */
+  readonly MaxCLL_String?: string
   /** Maximum content light level (source) */
   readonly MaxCLL_Source?: string
+  /** Maximum content light level (if incoherencies), with measurement */
+  readonly MaxCLL_Original?: number
   /** Maximum content light level (if incoherencies) */
-  readonly MaxCLL_Original?: string
+  readonly MaxCLL_Original_String?: string
   /** Maximum content light level (source if incoherencies) */
   readonly MaxCLL_Original_Source?: string
   /** Maximum frame average light level */
-  readonly MaxFALL?: string
-  /** Maximum frame average light level (source) */
+  readonly MaxFALL?: number
+  /** Maximum frame average light level */
+  readonly MaxFALL_String?: string
+  /** Maximum frame average light level (source), with measurement */
   readonly MaxFALL_Source?: string
   /** Maximum frame average light level (if incoherencies) */
-  readonly MaxFALL_Original?: string
+  readonly MaxFALL_Original?: number
+  /** Maximum frame average light level (if incoherencies), with measurement */
+  readonly MaxFALL_Original_String?: string
   /** Maximum frame average light level (source if incoherencies) */
   readonly MaxFALL_Original_Source?: string
 }


### PR DESCRIPTION
Allow to get rid of `unsafe-eval` and `wasm-unsafe-eval` CSP flags in a web environment.

Fix https://github.com/buzz/mediainfo.js/issues/184

Test don't pass, as previously, because of a missing test file.

I don't know if I made everything right regarding the MediaInfo binding update, but the library seems to work just fine.

